### PR TITLE
Demo on Comparison of performance of S-Rerf against other classifiers on Real EEG data for Grasp detection

### DIFF
--- a/Python/rerf/rerfClassifier.py
+++ b/Python/rerf/rerfClassifier.py
@@ -317,7 +317,7 @@ class rerfClassifier(BaseEstimator, ClassifierMixin):
             self.mtry_ = int(np.log2(num_features))
         elif isinstance(self.max_features, int):
             self.mtry_ = self.max_features
-        elif isinstance(self.max_features, float) and 0 <= self.max_features <= 1:
+        elif isinstance(self.max_features, float) and self.max_features > 0:
             self.mtry_ = int(self.max_features * num_features)
         else:
             raise ValueError("max_features has unexpected value")


### PR DESCRIPTION
**Description** 
Goal: Compare performance of S-Rerf with different classifiers on grasp detection using real EEG data.

This demo is a Jupyter Notebook documentation analyzing the performance of S-Rerf against classifiers like K-Nearest Neighbors, Random Forest and Multi-Layer Perceptron on structured EEG data. To keep the structure of the data, binning (based on the concept of moving average filter) is done before training on the data. The challenge faced is that the data is highly unbalanced so it is balanced before training. The metric used for evaluation are precision curves, balanced accuracy and mean test error. 

Output: The precision, balanced accuracy and mean test error plots that compare performance of S-Rerf with different classifiers. 

Code and Details of the demo:
https://nbviewer.jupyter.org/github/NeuroDataDesign/team-forbidden-forest/blob/master/Sanika/Final_PR_upload.ipynb